### PR TITLE
Extra schemas before catch-all schema

### DIFF
--- a/templates/storage-schemas.conf.j2
+++ b/templates/storage-schemas.conf.j2
@@ -11,11 +11,11 @@ retentions = 10s:6h,1m:7d,10m:1y
 pattern = ^collectd.*
 retentions = 10s:6h,1m:7d,10m:1y
 
-[default_1min_for_1day]
-pattern = .*
-retentions = 60s:1d
-
 {% for key, value in graphite_storage_schemas_extra.iteritems() %}
 [{{ key }}]
 {{ value }}
 {% endfor %}
+
+[default_1min_for_1day]
+pattern = .*
+retentions = 60s:1d


### PR DESCRIPTION
The 'default_1min_for_1day' schema is a catch-all, so any extra schemas defined will never match if they are listed below the catch-all.